### PR TITLE
Update NavigationView api

### DIFF
--- a/ExampleApp/Shared/ExampleApp.swift
+++ b/ExampleApp/Shared/ExampleApp.swift
@@ -21,21 +21,23 @@ struct NavigatorDemoApp: App {
 
             let navigator = Navigator(rootScreen: Screens.rootScreen, viewFactory: MyViewFactory())
 
-            RootScreen(currentScreen: .rootScreen)
-                .modifier(NavigatorViewBinding())
-                .accentColor(.black)
-                .environmentObject(navigator)
-                #if os(iOS)
-                .task {
+            NavigationView.with(navigator) {
+                RootScreen(currentScreen: .rootScreen)
+            }
+            .accentColor(.black)
 
-                    // Uncomment to test programatic view dismissal
-                    // await delay(5)
-                    // navigator.popToFirstGreenScreenOrRoot(id: UUID(uuidString: "d59bb9c3-f026-4890-b612-2dfa78bf6402")!)
+            #if os(iOS)
+            .navigationViewStyle(.stack)
+            .task {
 
-                    // Uncomment to test programatic stack building
-                    // await navigator.navigateWith(stack: .blueScreen(), .greenScreen(), .blueScreen())
-                }
-                #endif
+                // Uncomment to test programatic view dismissal
+                //   await delay(5)
+                //   navigator.popToFirstGreenScreenOrRoot(id: UUID(uuidString: "d59bb9c3-f026-4890-b612-2dfa78bf6402")!)
+
+                // Uncomment to test programatic stack building
+                //   await navigator.navigateWith(stack: .blueScreen(), .greenScreen(), .blueScreen())
+            }
+            #endif
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ and add the `NavigatorViewBinding` view modifier
 struct MyApp: App {
     var body: some Scene {
         WindowGroup {
-            RootScreen()
-                .modifier(NavigatorViewBinding())
-                .environmentObject(Navigator(rootScreen: Screens.rootScreen, viewFactory: MyViewFactory())
+            NavigationView.with(Navigator(rootScreen: Screens.rootScreen, viewFactory: MyViewFactory()) {
+                RootScreen()
+            }    
         }
     }
 }
@@ -286,21 +286,21 @@ struct MyApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootScreen(currentScreen: .rootScreen)
-                .modifier(NavigatorViewBinding())
-                .environmentObject(navigator)
-                .task {
-                    // mimic a system event, such as a notification 
+            NavigationView.with(navigator) {
+                RootScreen(currentScreen: .rootScreen)
+            }          
+            .task {
+                // mimic a system event, such as a notification 
                     
-                    // create an artificial delay of 10 seconds after the app starts up
-                    try! await Task.sleep(nanoseconds: 10_000_000_000)
-                    
-                    // User navigates to different views, adding to the navStack
-                    
-                    // However far along the user is, this will pop to the first 
-                    // detailScreen with called id, or pop to the root screen
-                    navigator.popToDetailWithSpecificIdOrRoot(id: "detail-123")
-                }
+                // create an artificial delay of 10 seconds after the app starts up
+                try! await Task.sleep(nanoseconds: 10_000_000_000)
+                 
+                // User navigates to different views, adding to the navStack
+                
+                // However far along the user is, this will pop to the first 
+                // detailScreen with called id, or pop to the root screen
+                navigator.popToDetailWithSpecificIdOrRoot(id: "detail-123")
+            }
         }
     }
 }

--- a/Sources/Navigator/NavigationBindings.swift
+++ b/Sources/Navigator/NavigationBindings.swift
@@ -53,17 +53,3 @@ public struct NavigationBinding<ViewFactoryImpl: ViewFactory, ScreenIdentifer: H
             })
     }
 }
-
-/// Apply this ViewModifier to the root ScreenView
-/// of your app to be able to cal Navigation methods
-public struct NavigatorViewBinding: ViewModifier {
-    
-    public init() {}
-    
-    public func body(content: Content) -> some View {
-        NavigationView { content }
-            #if os(iOS)
-            .navigationViewStyle(.stack)
-            #endif
-    }
-}

--- a/Sources/Navigator/NavigationView+Ext.swift
+++ b/Sources/Navigator/NavigationView+Ext.swift
@@ -1,0 +1,26 @@
+//
+//  NavigationView+Ext.swift
+//  
+//
+//  Created by Sean Najera on 2/20/22.
+//
+
+import SwiftUI
+
+public extension NavigationView {
+
+    /// Initializes the NavigationView with the instance of Navigator added into the
+    /// environment as an object. The root content should return a ScreenView.
+    /// All views pushed onto the NavigationView will receive the same Navigator
+    /// insatnce used to dynamically navigate between screens.
+    @ViewBuilder
+    static func with<ScreenID: Hashable, VF: ViewFactory>(
+        _ navigator: Navigator<ScreenID, VF>,
+        @ViewBuilder _ root: () -> Content
+    ) -> some View {
+        NavigationView {
+            root()
+        }
+        .environmentObject(navigator)
+    }
+}

--- a/Sources/Navigator/ScreenView.swift
+++ b/Sources/Navigator/ScreenView.swift
@@ -27,7 +27,7 @@ public protocol ScreenView: View {
 }
 
 public extension View {
-    
+
     /// Helper method to bind NavigationBindings modifier to current Screen View.
     /// Call this method to allow Screen View to use Navigator property
     @inlinable


### PR DESCRIPTION
Change the way `Navigator` is initialized with the `NavigationView` to be more user intuitive

* Initialize library with  a single call to `NavigationView.with(_:_:)` rather than separate modifiers